### PR TITLE
added @TC102 in NewsEditingFunctionality.feature, theUserEntersIntoTh…

### DIFF
--- a/src/main/java/com/greencity/ui/page/econewspage/CreateEditNewsPage.java
+++ b/src/main/java/com/greencity/ui/page/econewspage/CreateEditNewsPage.java
@@ -228,9 +228,6 @@ public String getAuthorName(){return authorLabel.getText();}
     public String getContentInputFieldText() {
         return textContentComponent.getContentInputTextFieldText();
     }
-    public String getContentWarningCounterText(){
-        return textContentComponent.getContentWarningCounterText();
-    }
 
     @Step("Fill '{titleText}' into 'Title Input' text field")
     public CreateEditNewsPage fillTitleInputTextField(String titleText) {

--- a/src/test/java/com/greencity/cucumber/steps/NewsEditingSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/NewsEditingSteps.java
@@ -136,4 +136,18 @@ public class NewsEditingSteps {
                 .clickDeleteButton()
                 .clickYesButton();
     }
+
+    @When("The user enters {string} into the content field")
+    public void theUserEntersIntoTheContentField(String content) {
+        String result = content.replaceAll("<SPACE>"," ");
+        createEditNewsPage.enterTextIntoTextContentField(result);
+    }
+
+    @Then("The warning message should say {string}")
+    public void theWarningMessageShouldSay(String expectedMessage) {
+        String actualMessage = createEditNewsPage.getContentWarningCounterText().trim();
+        softAssert.assertEquals(actualMessage, expectedMessage,
+                "The text of the warning message does not match the expected one");
+
+    }
 }

--- a/src/test/resources/features/NewsEditingFunctionality.feature
+++ b/src/test/resources/features/NewsEditingFunctionality.feature
@@ -34,3 +34,22 @@ Feature: News Editing Functionality
     And The user cancels the edit
     Then The user should be redirected to Eco News page
     And The original news title should be displayed
+
+  @TC102
+    @short_content_is_not_accepted
+  Scenario Outline: Verify that content shorter than 20 characters is not accepted
+    When The user clicks the "Edit news" button
+    And The user enters "<text>" into the content field
+    Then The warning message should say "Not enough characters. Left: <expected>"
+    And The "Publish" button should be disabled
+    When The user cancels the edit
+    And Clean up test news
+
+    Examples:
+      | text                | expected |
+      | <SPACE>             | 19       |
+      | T                   | 19       |
+      | TestString_19_Chars | 1        |
+      | 1                   | 19       |
+      | 10 chars!!          | 10       |
+      | !                   | 19       |


### PR DESCRIPTION
1. Removed merod as duplicate from CreateEditNewsPage.java
```java
    public String getContentWarningCounterText(){
        return textContentComponent.getContentWarningCounterText();
    }
```
2. Added metods into NewsEditingSteps.class
```java
    @When("The user enters {string} into the content field")
    public void theUserEntersIntoTheContentField(String content) {
        String result = content.replaceAll("<SPACE>"," ");
        createEditNewsPage.enterTextIntoTextContentField(result);
    }

    @Then("The warning message should say {string}")
    public void theWarningMessageShouldSay(String expectedMessage) {
        String actualMessage = createEditNewsPage.getContentWarningCounterText().trim();
        softAssert.assertEquals(actualMessage, expectedMessage,
                "The text of the warning message does not match the expected one");

    }
```
3. Added TC into NewsEditingFunctionality.feature
```java
  @TC102
    @short_content_is_not_accepted
  Scenario Outline: Verify that content shorter than 20 characters is not accepted
    When The user clicks the "Edit news" button
    And The user enters "<text>" into the content field
    Then The warning message should say "Not enough characters. Left: <expected>"
    And The "Publish" button should be disabled
    When The user cancels the edit
    And Clean up test news

    Examples:
      | text                | expected |
      | <SPACE>             | 19       |
      | T                   | 19       |
      | TestString_19_Chars | 1        |
      | 1                   | 19       |
      | 10 chars!!          | 10       |
      | !                   | 19       |
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new test steps to verify content input and warning messages in news editing scenarios.
  - Introduced a scenario outline to ensure news content shorter than 20 characters is not accepted, including multiple test cases for different inputs and expected warnings.
- **Refactor**
  - Removed the method for retrieving the content warning counter text from the news creation and editing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->