### PR TITLE
Adding allure tags to EditNewsCardTest, CheckingTagSelectionTest, EcoNewsClientTest

### DIFF
--- a/src/test/java/com/greencity/api/EcoNewsClientTest.java
+++ b/src/test/java/com/greencity/api/EcoNewsClientTest.java
@@ -1,15 +1,22 @@
-package com.greencity.api.testRunners;
+package com.greencity.api;
 
 import com.greencity.api.clients.EcoNewsClient;
 import com.greencity.api.models.DateUtils;
 import com.greencity.api.models.EcoNews;
+import com.greencity.api.testRunners.ApiTestRunner;
 import com.greencity.utils.TestValueProvider;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Issue;
+import io.qameta.allure.Owner;
 import io.restassured.response.Response;
+import jdk.jfr.Description;
 import lombok.SneakyThrows;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -39,6 +46,11 @@ public class EcoNewsClientTest extends ApiTestRunner {
 
     }
 
+    @Description("Verify that API successfully returns Eco News card by ID with status code 200")
+    @Epic("Eco News API")
+    @Feature("Get Eco News Card By Id")
+    @Issue("152")
+    @Owner("Nataliia Hrusha")
     @Test(dataProvider = "languageProvider")
     public void getEcoNewsById(String language, List<String> expectedTags) {
         Response response = ecoNewsClient.getEcoNewsByIdRawResponse(KNOWN_EXISTING_NEWS_ID, language);
@@ -53,7 +65,7 @@ public class EcoNewsClientTest extends ApiTestRunner {
 
     @DataProvider
     public Object[][] languageProvider() {
-        return new Object[][] {
+        return new Object[][]{
                 {LANG_EN, Collections.singletonList("News")},
                 {LANG_UK, Collections.singletonList("Новини")}
         };

--- a/src/test/java/com/greencity/ui/CheckingTagSelectionTest.java
+++ b/src/test/java/com/greencity/ui/CheckingTagSelectionTest.java
@@ -6,6 +6,7 @@ import com.greencity.ui.data.Colors;
 import com.greencity.ui.page.econewspage.CreateEditNewsPage;
 import com.greencity.ui.page.econewspage.EcoNewsPage;
 import com.greencity.ui.testrunners.BaseTestRunner;
+import io.qameta.allure.*;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
@@ -26,6 +27,12 @@ public class CheckingTagSelectionTest extends BaseTestRunner {
         ).iterator();
     }
 
+
+    @Description("Verify that the user can select between 1 and 3 tags and news is published with selected tags.")
+    @Epic("Create News")
+    @Feature("Checking Tag Selection")
+    @Issue("15")
+    @Owner("Nataliia Hrusha")
     @Test(dataProvider = "tagSelectionProvider")
     public void verifyTagSelection(TagButton[] tagsToSelect) {
         String newsTitle = "TestNews_" + UUID.randomUUID();
@@ -75,6 +82,11 @@ public class CheckingTagSelectionTest extends BaseTestRunner {
         softAssert.assertAll();
     }
 
+    @Description("Verify that a fourth tag cannot be selected.")
+    @Epic("Create News")
+    @Feature("Checking Tag Selection")
+    @Issue("15")
+    @Owner("Nataliia Hrusha")
     @Test
     public void verifyCantSelectFourTag() {
         String newsTitle = "TestNews_" + UUID.randomUUID();

--- a/src/test/java/com/greencity/ui/EditNewsCardTest.java
+++ b/src/test/java/com/greencity/ui/EditNewsCardTest.java
@@ -9,8 +9,7 @@ import com.greencity.ui.page.econewspage.CreateEditNewsPage;
 import com.greencity.ui.page.econewspage.EcoNewsPage;
 import com.greencity.ui.page.econewspage.NewsCardPage;
 import com.greencity.ui.testrunners.BaseTestRunner;
-import io.qameta.allure.Issue;
-import io.qameta.allure.Owner;
+import io.qameta.allure.*;
 import jdk.jfr.Description;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -34,6 +33,7 @@ public class EditNewsCardTest extends BaseTestRunner {
     private EcoNewsPage ecoNewsPage;
 
     @BeforeMethod
+    @Step("Create test news")
     public void createTestNews() {
         newsTitle = "TestNews_" + UUID.randomUUID();
         newsContent = "Content_" + UUID.randomUUID();
@@ -50,6 +50,11 @@ public class EditNewsCardTest extends BaseTestRunner {
         newsCardPage = ecoNewsPage.goToNewsCardPage(newsTitle);
     }
 
+    @Description("Verify that the edited news cannot be submitted without a title.")
+    @Epic("Edit News")
+    @Feature("Validation – empty title field")
+    @Issue("101")
+    @Owner("Nataliia Hrusha")
     @Test
     public void verifyNewsCannotBeSubmittedWithoutTitle() {
         CreateEditNewsPage createEditNewsPage = newsCardPage.clickEditButton();
@@ -78,6 +83,11 @@ public class EditNewsCardTest extends BaseTestRunner {
 
     }
 
+    @Description("Verify that only the author of the news can see the \"Edit news\" button.")
+    @Epic("Edit News")
+    @Feature("Edit button visible to author")
+    @Issue("97")
+    @Owner("Nataliia Hrusha")
     @Test
     public void verifyEditButtonVisibleToAuthor() {
         String actualUserName = homePage.getLoggedHeader().getUserNameText();
@@ -99,7 +109,11 @@ public class EditNewsCardTest extends BaseTestRunner {
         softAssert.assertAll();
     }
 
-
+    @Description("Verify that only the author of the news can see the \"Edit news\" button.")
+    @Epic("Edit News")
+    @Feature("Cancel editing")
+    @Issue("104")
+    @Owner("Nataliia Hrusha")
     @Test
     public void verifyCancelEditing() {
         newsTitleAfterEditing = "TestNews after editing" + UUID.randomUUID();
@@ -133,20 +147,20 @@ public class EditNewsCardTest extends BaseTestRunner {
     @Description("Verify that content shorter than 20 characters is not accepted.")
     @Issue("102")
     @Owner("Maksym Ahafonov")
-    public void verifyShortContentNotAccepted()  {
+    public void verifyShortContentNotAccepted() {
         String errorMsgText = "Not enough characters. Left: %s";
-        Map<String,Integer> testData = new TreeMap<>();
-        testData.put("T",19);
-        testData.put("TestString_19_Chars",1);
-        testData.put("1",19);
-        testData.put("10 chars!!",10);
-        testData.put("!",19);
-        testData.put(" ",19);
+        Map<String, Integer> testData = new TreeMap<>();
+        testData.put("T", 19);
+        testData.put("TestString_19_Chars", 1);
+        testData.put("1", 19);
+        testData.put("10 chars!!", 10);
+        testData.put("!", 19);
+        testData.put(" ", 19);
 
         SoftAssert softAssert = new SoftAssert();
         CreateEditNewsPage createEditNewsPage = newsCardPage.clickEditButton();
 
-        for(var dataPair : testData.entrySet()){
+        for (var dataPair : testData.entrySet()) {
             String testText = dataPair.getKey();
             int expectedNumber = dataPair.getValue();
             createEditNewsPage.enterTextIntoTextContentField(testText);
@@ -156,7 +170,7 @@ public class EditNewsCardTest extends BaseTestRunner {
                 "The text of the warning message does not match with the expected one: "
             );
             softAssert.assertFalse(createEditNewsPage.getPublishButton().isEnabled(),
-                "The Publish button should be disabled when all required fields are not filled out");
+                    "The Publish button should be disabled when all required fields are not filled out");
         }
         createEditNewsPage.clickExitButton()
                 .clickYesCancelButton();
@@ -164,6 +178,7 @@ public class EditNewsCardTest extends BaseTestRunner {
     }
 
     @AfterMethod
+    @Step("Delete test news")
     public void deleteTestNews() {
         ecoNewsPage = homePage
                 .gotoEcoNewsPage()

--- a/src/test/java/com/greencity/ui/EditNewsCardTest.java
+++ b/src/test/java/com/greencity/ui/EditNewsCardTest.java
@@ -109,7 +109,7 @@ public class EditNewsCardTest extends BaseTestRunner {
         softAssert.assertAll();
     }
 
-    @Description("Verify that only the author of the news can see the \"Edit news\" button.")
+    @Description("Verify that clicking \"Cancel\" discards changes and returns to the original view.")
     @Epic("Edit News")
     @Feature("Cancel editing")
     @Issue("104")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced test reporting and traceability by adding detailed Allure annotations to multiple test methods.
  - Introduced a new test to verify that selecting a fourth tag is not possible when publishing news.
  - Improved documentation and metadata for test setup and cleanup steps.
  - No changes to core test logic or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->